### PR TITLE
Adjust helper text relating to Expo Go

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ const LINKING_ERROR =
   `The package 'react-native-objc-runtime' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo managed workflow\n';
+  "- You are not running this in the Expo Go app (it doesn't include this module's native code)\n";
 
 const ObjcRuntime = NativeModules.ObjcRuntime
   ? NativeModules.ObjcRuntime


### PR DESCRIPTION
This PR changes the helper text to mention Expo Go to be more precise. Omitted guidance on the managed workflow and prefer not to imply that reflecting native APIs from JS is sanctioned in Expo (of course folks are free to try what they'd like on RN and other platforms -- just prefer different guidance for Expo developers).

Ran Prettier and ESLint to conform with the formatting preferences.